### PR TITLE
compiler:  handle cyclic dependencies

### DIFF
--- a/morphotactics/slot.py
+++ b/morphotactics/slot.py
@@ -19,3 +19,4 @@ class Slot:
     self.fst = None
     self.rules = rules # list of rules and their continuation classes
     self.start = start
+    self.final_states = []


### PR DESCRIPTION
No longer assume dependencies are acyclic (in which case we could've used a one-pass DFS to get a topological sort). 

We now make 2 DFS passes
* 1 to copy FSTs into the main one with pywrapfst
* another to glue the Slots)

Also modified Slot to store final states of its FST, for use in the second DFS pass by the compiler