### PR TITLE
Add tests and helpers for weighted FSTs

### DIFF
--- a/morphotactics/morphotactics.py
+++ b/morphotactics/morphotactics.py
@@ -1,4 +1,5 @@
 import pynini
+from pynini.lib import pynutil
 from morphotactics.stem_guesser import StemGuesser
 
 # A recursive, polymorphic depth-first graph search algorithm
@@ -89,7 +90,7 @@ def compile(slots):
         # we will concatenate the rule with the continuation class' FST in the second DFS
 
         # place lower on the input side so that FST can take in input from lower alphabet to perform analysis
-        rule = pynini.cross(lower, upper)
+        rule = pynutil.add_weight(pynini.cross(lower, upper), weight)
 
         # copy rule to fst arc by arc, starting from state start_slot
         old_num_states = fst.num_states()

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -5,6 +5,7 @@ import pytest
 import pynini
 import pywrapfst
 import math
+import random
 
 # helpers
 # checks if input_str is in the language of the FSA
@@ -49,7 +50,7 @@ def all_strings_from_chain(automaton):
     for (_, k, w) in path:
       if k:
         chars.append(chr(k))
-        weight += w
+        weight += w # semiring product in the tropical semiring is addition
     strings.append((''.join(chars), weight))
   return strings
 
@@ -71,7 +72,11 @@ def correct_transduction_and_weights(fst, input_str, expected_paths):
   expected_paths = sorted(expected_paths, key=lambda x: x[1])
 
   for ((str1, weight1), (str2, weight2)) in zip(output_paths, expected_paths):
-    if str1 != str2 or not math.isclose(weight1, weight2, rel_tol=1e-5):
+    if str1 != str2:
+      print(str1 + ' does not match ' + str2)
+      return False
+    if math.isclose(weight1, weight2, rel_tol=1e-10):
+      print('path ' + str(str1) + ': ' + str(weight1) + ' does not match ' + str(weight2))
       return False
 
   return True
@@ -845,3 +850,80 @@ def test_cycle_period_at_least_two_cycle_excludes_starting_class():
     #   class3 to class4 (terminal)
     assert analyze(fst, 'b' + (cyclic_lower * i) + 'ln' + 'r') == 'a' + (cyclic_upper * i) + 'km' + 'q'
     assert analyze(fst, 'f' + (cyclic_lower * i) + 'ln' + 'r') == 'e' + (cyclic_upper * i) + 'km' + 'q'
+
+def test_single_weighted_class():
+  fst = compile({
+    Slot('class1',
+      [
+        ('a', 'b', [], 0.5),
+        ('c', 'd', [], 0.25),
+        ('e', 'f', [], 0.75),
+        ('g', 'h', [], 0.1)
+      ],
+      start=True)
+  })
+
+  # shortest distance from the start to final state is 0.1
+  assert math.isclose(float(pywrapfst.shortestdistance(fst)[1]), 0.1, rel_tol=1e-5)
+
+  # correct transduction and correct weight
+  assert correct_transduction_and_weights(fst, 'b', [('a', 0.5)])
+  assert correct_transduction_and_weights(fst, 'd', [('c', 0.25)])
+  assert correct_transduction_and_weights(fst, 'f', [('e', 0.75)])
+  assert correct_transduction_and_weights(fst, 'h', [('g', 0.1)])
+
+def test_multiple_weighted_classes():
+  weights = {}
+  for transition in ['ba', 'dc', 'fe', 'hg', 'ji', 'lk', 'nm', 'po', 'rq', 'ts']:
+    weights[transition] = random.random()
+  
+  fst = compile({
+    Slot('class1',
+      [
+        ('a', 'b', ['class2'], weights['ba']),
+        ('c', 'd', [], weights['dc']),
+        ('e', 'f', ['class2', 'class3'], weights['fe'])
+      ],
+      start=True),
+    Slot('class2', 
+      [
+        ('g', 'h', [], weights['hg']),
+        ('i', 'j', [], weights['ji']),
+        ('k', 'l', ['class3'], weights['lk']),
+      ]
+    ),
+    Slot('class3', 
+      [
+        ('m', 'n', [], weights['nm']),
+        ('o', 'p', [], weights['po']),
+      ]
+    ),
+    Slot('class4', 
+      [
+        ('q', 'r', [], weights['rq']),
+        ('s', 't', [], weights['ts']),
+      ], start=True)
+  })
+
+  # class1 alone
+  assert correct_transduction_and_weights(fst, 'd', [('c', weights['dc'])])
+
+  # class1 to class2
+  assert correct_transduction_and_weights(fst, 'bh', [('ag', weights['ba'] + weights['hg'])])
+  assert correct_transduction_and_weights(fst, 'bj', [('ai', weights['ba'] + weights['ji'])])
+  assert correct_transduction_and_weights(fst, 'fh', [('eg', weights['fe'] + weights['hg'])])
+  assert correct_transduction_and_weights(fst, 'fj', [('ei', weights['fe'] + weights['ji'])])
+
+  # class1 to class2 to class3
+  assert correct_transduction_and_weights(fst, 'bln', [('akm', weights['ba'] + weights['lk'] + weights['nm'])])
+  assert correct_transduction_and_weights(fst, 'blp', [('ako', weights['ba'] + weights['lk'] + weights['po'])])
+  assert correct_transduction_and_weights(fst, 'fln', [('ekm', weights['fe'] + weights['lk'] + weights['nm'])])
+  assert correct_transduction_and_weights(fst, 'flp', [('eko', weights['fe'] + weights['lk'] + weights['po'])])
+
+  # class1 to class3
+  assert correct_transduction_and_weights(fst, 'fn', [('em', weights['fe'] + weights['nm'])])
+  assert correct_transduction_and_weights(fst, 'fp', [('eo', weights['fe'] + weights['po'])])
+
+  # class4
+  assert correct_transduction_and_weights(fst, 'r', [('q', weights['rq'])])
+  assert correct_transduction_and_weights(fst, 't', [('s', weights['ts'])])


### PR DESCRIPTION
We add 2 utility functions:

* all_strings_from_chain (from https://github.com/dmort27/fststr): generate all output strings transduced by an FST and their weights
* correct_transduction_and_weights: Check if the FST applied to some input generates the expected list of strings with expected weights
 
In the weighted FST tests, we compile the Slots into an FST, then compose an input string (which pynini converts into a linear chain automata) with the FST, then pass this into all_strings_from_chain to see all the outputs that can be transduced from the input string, along with the weights. Then we call correct_transduction_and_weights to compare the expected output strings and their weights with the result of all_strings_from_chain. 